### PR TITLE
Make NEXT_APP_URL an Optional ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cp .env.example .env
 npx prisma db push
 ```
 
-### Configure authentication
+### Configure authentication (required)
 
 GitHub and Okta authentication settings are available as defaults, but thanks to NextAuth.js, you can configure your Beam instance with most other common authentication providers.
 

--- a/README.md
+++ b/README.md
@@ -72,4 +72,6 @@ One-click deploy:
 
 ⚠️ Remember to update your callback URLs after deploying.
 
-##Some note about the NEXT_APP_URL environment variable
+## NEXT_APP_URL environment variable
+
+When deploying to vercel you may have to set the NEXT_APP_URL which is validated as a URL so be sure to include the full URL. For example: https:///www.appName.vercel.app in your Environment Variables.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ One-click deploy:
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fplanetscale%2Fbeam)
 
 ⚠️ Remember to update your callback URLs after deploying.
+
+##Some note about the NEXT_APP_URL environment variable

--- a/env/server.ts
+++ b/env/server.ts
@@ -48,6 +48,7 @@ export const serverEnv = {
     DATABASE_URL: str(),
     NEXT_APP_URL: url({
       devDefault: 'http://localhost:3000',
+      allowEmpty: true
     }),
     NEXTAUTH_SECRET: str({
       devDefault: 'xxx',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -190,6 +190,8 @@ module.exports = {
             '--tw-prose-quotes': 'var(--text-primary)',
             '--tw-prose-quote-borders': 'var(--border-secondary)',
             '--tw-prose-code': 'var(--text-primary)',
+            '--tw-prose-th-borders': 'var(--border-secondary)',
+            '--tw-prose-td-borders': 'var(--border-primary)',
             p: {
               lineHeight: '24px',
               marginBottom: '1em',


### PR DESCRIPTION
This makes the NEXT_APP_URL optional optional so you can deploy without errors if slack integration is turned off, but leaves the URL Type safety in place for when it is used.

Another option would be to use the slackParser function to validate, but since it only validates the string you would lose URL Type safety which ensures an env var is a url with a protocol and hostname.

Resolves #57